### PR TITLE
chore(deps): bump typescript to 6.0.3 and node-gyp to 13.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "devDependencies": {
     "@types/node": "^26.0.0",
     "ts-node": "^10.9.2",
-    "typescript": "^5.0.0"
+    "typescript": "^6.0.3"
   },
   "files": [
     "dist/**/*",
@@ -109,6 +109,6 @@
   },
   "optionalDependencies": {
     "node-addon-api": "^8.5.0",
-    "node-gyp": "^12.2.0"
+    "node-gyp": "^13.0.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "commonjs",
+    "module": "node16",
     "lib": ["ES2020"],
     "outDir": "./dist",
     "rootDir": "./src",
@@ -12,7 +12,7 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
     "resolveJsonModule": true,
     "types": ["node"]
   },


### PR DESCRIPTION
Supersedes Dependabot PRs #56 (typescript) and #63 (node-gyp), which could not be merged as-is.

typescript 6.0 turns the deprecated moduleResolution "node" (node10) into a hard error (TS5107). Migrate tsconfig to module/moduleResolution "node16" — the correct modern setting for this CommonJS Node library and the permanent fix (survives TS 7, no ignoreDeprecations stopgap). The package has no "type": "module", so emit stays CommonJS; verified the full tsc build succeeds and every dist .js/.d.ts is byte-identical to before.

node-gyp 13 raises its Node engine floor to
^22.22.2 || ^24.15.0 || >=26.0.0. It's an optionalDependency used only by the build:native maintainer script (postinstall does not build), so consumer installs are unaffected. On older Node it is skipped and the build falls back to npm's bundled node-gyp; the native build still succeeds (verified: gyp info ok).