### PR TITLE
feat(overlay): add opt-in transparent overlay

### DIFF
--- a/docs/STEAM_OVERLAY_INTEGRATION.md
+++ b/docs/STEAM_OVERLAY_INTEGRATION.md
@@ -104,6 +104,9 @@ Adds Steam overlay support to an Electron BrowserWindow.
   - `title?: string` - Window title (default: "Electron Steam App")
   - `fps?: number` - Frame rate (default: 60)
   - `vsync?: boolean` - Enable VSync (default: true)
+  - `transparent?: boolean` - Present an empty transparent frame for Steam to
+    draw into instead of mirroring the window (default: false). Availability
+    varies by platform - see [Transparent mode](#transparent-mode).
 
 **Returns:** `boolean` - True if overlay was successfully added
 
@@ -122,6 +125,58 @@ if (success) {
   console.log("Failed to enable overlay");
 }
 ```
+
+### isTransparent()
+
+Whether the overlay window is transparent rather than mirroring the app.
+
+**Returns:** `boolean`
+
+Only relevant if you passed `transparent: true`. Without it this always returns
+`false`, and mirroring is unchanged.
+
+Transparency is a request, not a guarantee: where the platform cannot provide
+it the overlay falls back to mirroring, and it does so silently. This is how
+you find out which one you got - most usefully so a support report can say
+whether transparency was actually in effect on the machine that hit a problem.
+
+```typescript
+steam.addElectronSteamOverlay(win, { transparent: true });
+console.log(
+  steam.overlay.isTransparent()
+    ? 'Overlay: transparent'
+    : 'Overlay: mirroring (transparency unavailable on this machine)',
+);
+```
+
+## Transparent mode
+
+By default the overlay window mirrors the app via `beginFrameSubscription`,
+which is capped at 30fps on a non-offscreen window. Because the overlay window
+sits on top, that cap is the framerate the user sees.
+
+In transparent mode nothing is captured. The window presents an empty
+transparent frame and Steam draws into it on the hooked `Present`, so the app
+shows through at its own framerate, and Steam notifications and the FPS counter
+are drawn as well.
+
+What transparency needs differs by platform:
+
+| Platform | Needs | Notes |
+| --- | --- | --- |
+| Windows | D3D11 + DirectComposition | Falls back to the WGL window, which is opaque |
+| macOS | Metal | The layer is already configured for per-pixel alpha |
+| Linux | A depth-32 ARGB visual and a running compositing manager | X11 does no blending on its own |
+
+Where those are unavailable the overlay falls back to mirroring - the same
+behaviour as not passing the option at all. `isTransparent()` reports which
+one is in effect.
+
+On Windows the transparent overlay window is also made an *owned* window
+rather than `WS_EX_TOPMOST`, so it stays above the app it belongs to instead
+of above every application on the desktop. It has to be: unlike the mirror,
+this window is on screen permanently. Nothing to configure - the owner is
+taken from the `BrowserWindow` you pass in.
 
 ### `isOverlayAvailable()`
 

--- a/native/binding.gyp
+++ b/native/binding.gyp
@@ -26,6 +26,7 @@
           "sources": [ "windows-overlay.cpp" ],
           "libraries": [
             "-lopengl32",
+            "-ldwmapi",
             "-lgdi32",
             "-luser32"
           ],

--- a/native/linux-overlay.cpp
+++ b/native/linux-overlay.cpp
@@ -66,6 +66,11 @@ public:
     std::atomic<bool> isMapped{false};  // true while window is XMapRaised, false after XUnmapWindow
     std::mutex renderMutex;
 
+    // Transparent mode: present empty frames and let the game window show
+    // through, instead of mirroring it into a texture. See isTransparent().
+    bool transparentRequested = false;
+    bool hasArgbVisual = false;
+
     // Cursor warp suppression on Steam overlay close.
     // When Shift+Tab opens the overlay, Steam saves the cursor position.
     // When the overlay closes, Steam warps the cursor back to that saved position.
@@ -93,11 +98,13 @@ public:
         return (long long)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
     }
 
-    bool init(int w, int h, const char* title) {
+    bool init(int w, int h, const char* title, bool transparent = false) {
         width = w;
         height = h;
         
-        OverlayLog("Initializing Linux overlay window: %dx%d", w, h);
+        OverlayLog("Initializing Linux overlay window: %dx%d (%s)", w, h,
+                   transparent ? "transparent" : "mirroring");
+        transparentRequested = transparent;
         
         XInitThreads(); // Required for multi-threaded X11 access
         
@@ -151,8 +158,30 @@ public:
             return false;
         }
         
-        // Pick the first FBConfig
+        // Pick the first FBConfig, as before.
         fbConfig = fbConfigs[0];
+
+        // Only in transparent mode, prefer one with a depth-32 ARGB visual.
+        // GLX_ALPHA_SIZE above is a minimum on the GL drawable, not a promise
+        // about the X visual -- glXChooseFBConfig will happily return a
+        // depth-24 config first, and per-pixel window alpha needs depth 32.
+        //
+        // Deliberately not applied to the mirroring path: it does not need
+        // alpha, and changing which visual existing callers get is not this
+        // option's business.
+        if (transparent) {
+            for (int i = 0; i < fbCount; i++) {
+                XVisualInfo* candidate = glXGetVisualFromFBConfig(display, fbConfigs[i]);
+                if (!candidate) continue;
+                if (candidate->depth == 32) {
+                    fbConfig = fbConfigs[i];
+                    hasArgbVisual = true;
+                    XFree(candidate);
+                    break;
+                }
+                XFree(candidate);
+            }
+        }
         XFree(fbConfigs);
         
         // Get visual info from FBConfig
@@ -162,6 +191,14 @@ public:
             XCloseDisplay(display);
             display = nullptr;
             return false;
+        }
+        if (transparent) {
+            OverlayLog("Chose visual depth %d (ARGB: %s)",
+                       visualInfo->depth, hasArgbVisual ? "yes" : "no");
+        }
+        if (transparentRequested && !hasArgbVisual) {
+            OverlayLogError("Transparency requested but no depth-32 visual is "
+                            "available; the overlay window will be opaque");
         }
         
         // Create colormap
@@ -499,6 +536,14 @@ public:
         // Swap buffers
         glXSwapBuffers(display, window);
         
+        pumpXEvents();
+    }
+
+    // Everything renderFrame does after the swap: input forwarding, the idle
+    // refocus and the flush. Factored out so present() can share it -- in
+    // transparent mode renderFrame is never called, and without this the X
+    // event pump would stop and Shift+Tab would stop reaching Steam.
+    void pumpXEvents() {
         // Process any pending X events
         while (XPending(display)) {
             XEvent event;
@@ -581,6 +626,47 @@ public:
         glFlush();
     }
 
+    // Transparent mode: swap an empty frame so Steam's glXSwapBuffers hook
+    // fires and it can draw the overlay, without copying the game window into
+    // a texture first. The clear colour is already (0,0,0,0), so on an ARGB
+    // visual with a compositor running the real window shows through.
+    void present() {
+        if (isDestroyed) return;
+        if (!isMapped) return;
+
+        std::lock_guard<std::mutex> lock(renderMutex);
+
+        if (!display || !glContext || !window) return;
+
+        if (!glXMakeCurrent(display, window, glContext)) {
+            OverlayLogError("Failed to make context current in present");
+            return;
+        }
+
+        glClear(GL_COLOR_BUFFER_BIT);
+        glXSwapBuffers(display, window);
+
+        pumpXEvents();
+    }
+
+    // Whether this window genuinely shows through. Two things have to hold:
+    // the visual has to carry an alpha channel (a depth-32 ARGB visual, not
+    // just a GLX config that reported GLX_ALPHA_SIZE), and a compositing
+    // manager has to be running -- X11 does not blend anything on its own.
+    bool isTransparent() {
+        if (isDestroyed || !display) return false;
+        return transparentRequested && hasArgbVisual && hasCompositor();
+    }
+
+    bool hasCompositor() const {
+        if (!display) return false;
+        // The standard handshake: a compositing manager owns _NET_WM_CM_S<screen>.
+        char name[32];
+        snprintf(name, sizeof(name), "_NET_WM_CM_S%d", DefaultScreen(display));
+        Atom cmAtom = XInternAtom(display, name, False);
+        return cmAtom != None && XGetSelectionOwner(display, cmAtom) != None;
+    }
+
     void destroy() {
         if (isDestroyed.exchange(true)) return;
         
@@ -645,6 +731,12 @@ static napi_value CreateOverlayWindow(napi_env env, napi_callback_info info) {
     napi_get_named_property(env, args[0], "height", &heightVal);
     napi_get_named_property(env, args[0], "title", &titleVal);
     
+    napi_value transparentVal;
+    bool transparent = false;
+    if (napi_get_named_property(env, args[0], "transparent", &transparentVal) == napi_ok) {
+        napi_get_value_bool(env, transparentVal, &transparent);
+    }
+    
     int width, height;
     napi_get_value_int32(env, widthVal, &width);
     napi_get_value_int32(env, heightVal, &height);
@@ -655,7 +747,7 @@ static napi_value CreateOverlayWindow(napi_env env, napi_callback_info info) {
     
     // Create window
     LinuxOverlayWindow* window = new LinuxOverlayWindow();
-    if (!window->init(width, height, title)) {
+    if (!window->init(width, height, title, transparent)) {
         delete window;
         napi_throw_error(env, nullptr, "Failed to create overlay window");
         return nullptr;
@@ -666,6 +758,35 @@ static napi_value CreateOverlayWindow(napi_env env, napi_callback_info info) {
     status = napi_create_external(env, window, nullptr, nullptr, &external);
     
     return external;
+}
+
+static napi_value PresentFrame(napi_env env, napi_callback_info info) {
+    size_t argc = 1;
+    napi_value args[1];
+    napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
+
+    LinuxOverlayWindow* window;
+    if (napi_get_value_external(env, args[0], (void**)&window) != napi_ok || !window) {
+        return nullptr;
+    }
+    window->present();
+    return nullptr;
+}
+
+static napi_value IsOverlayTransparent(napi_env env, napi_callback_info info) {
+    size_t argc = 1;
+    napi_value args[1];
+    napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
+
+    LinuxOverlayWindow* window = nullptr;
+    napi_value result;
+    bool transparent = false;
+    if (argc >= 1 &&
+        napi_get_value_external(env, args[0], (void**)&window) == napi_ok && window) {
+        transparent = window->isTransparent();
+    }
+    napi_get_boolean(env, transparent, &result);
+    return result;
 }
 
 static napi_value ShowOverlayWindow(napi_env env, napi_callback_info info) {
@@ -856,6 +977,8 @@ static napi_value Init(napi_env env, napi_value exports) {
         { "hideOverlayWindow",        nullptr, HideOverlayWindow,        nullptr, nullptr, nullptr, napi_default, nullptr },
         { "setOverlayFrame",          nullptr, SetOverlayWindowFrame,    nullptr, nullptr, nullptr, napi_default, nullptr },
         { "renderFrame",              nullptr, RenderFrame,              nullptr, nullptr, nullptr, napi_default, nullptr },
+        { "presentFrame",             nullptr, PresentFrame,             nullptr, nullptr, nullptr, napi_default, nullptr },
+        { "isOverlayTransparent",     nullptr, IsOverlayTransparent,     nullptr, nullptr, nullptr, napi_default, nullptr },
         { "destroyOverlayWindow",     nullptr, DestroyOverlayWindow,     nullptr, nullptr, nullptr, napi_default, nullptr },
         { "setDebugMode",             nullptr, SetDebugMode,             nullptr, nullptr, nullptr, napi_default, nullptr },
         { "setSteamGameAtomOnWindow",  nullptr, SetSteamGameAtomOnWindow,  nullptr, nullptr, nullptr, napi_default, nullptr },

--- a/native/macos-overlay.mm
+++ b/native/macos-overlay.mm
@@ -33,16 +33,18 @@ static BOOL g_debugMode = NO;
 @property (assign, nonatomic) int width;
 @property (assign, nonatomic) int height;
 @property (assign, nonatomic) BOOL isDestroyed;
+@property (assign, nonatomic) BOOL transparent;  // Present empty frames instead of mirroring
 @property (strong, nonatomic) NSWindow *electronWindow;  // Reference to Electron window for input forwarding
 @end
 
 @implementation MetalWindowWrapper
 
-- (instancetype)initWithWidth:(int)w height:(int)h title:(NSString *)title {
+- (instancetype)initWithWidth:(int)w height:(int)h title:(NSString *)title transparent:(BOOL)transparent {
     self = [super init];
     if (self) {
         _width = w;
         _height = h;
+        _transparent = transparent;
         
         // Initialize Metal device
         _device = MTLCreateSystemDefaultDevice();
@@ -108,7 +110,8 @@ static BOOL g_debugMode = NO;
         // Make window transparent - content comes from rendered frames
         [_window setBackgroundColor:[NSColor clearColor]];
         
-        MetalLog(@"[Metal Overlay] Metal window created (borderless, transparent): %dx%d", w, h);
+        MetalLog(@"[Metal Overlay] Metal window created (borderless, transparent, %@): %dx%d",
+                 _transparent ? @"empty frames" : @"mirroring", w, h);
         
         // Set up rendering pipeline
         [self setupRenderPipeline];
@@ -288,8 +291,12 @@ static BOOL g_debugMode = NO;
             return;
         }
         
-        // If we have a texture and pipeline, render it
-        if (_texture && _pipelineState) {
+        // In transparent mode there is deliberately nothing to draw: the render
+        // pass clears to alpha 0 and presents, so Steam's hook fires against an
+        // empty frame and the real window shows through underneath.
+        if (_transparent) {
+            // Nothing to encode.
+        } else if (_texture && _pipelineState) {
             [renderEncoder setRenderPipelineState:_pipelineState];
             [renderEncoder setVertexBuffer:_vertexBuffer offset:0 atIndex:0];
             [renderEncoder setFragmentTexture:_texture atIndex:0];
@@ -309,6 +316,16 @@ static BOOL g_debugMode = NO;
         [commandBuffer presentDrawable:drawable];
         [commandBuffer commit];
     }
+}
+
+// Whether this window genuinely shows through. The layer is configured for
+// per-pixel alpha unconditionally, so the only question is whether the caller
+// asked for empty frames rather than a mirror.
+- (BOOL)isTransparent {
+    if (_isDestroyed || !_metalView) {
+        return NO;
+    }
+    return _transparent && !_metalView.layer.opaque;
 }
 
 - (void)destroy {
@@ -362,13 +379,17 @@ static napi_value CreateOverlayWindow(napi_env env, napi_callback_info info) {
     }
     
     // Parse options
-    napi_value widthVal, heightVal, titleVal;
+    napi_value widthVal, heightVal, titleVal, transparentVal;
     int width = 1280, height = 720;
     char title[256] = "Electron Steam App";
+    bool transparent = false;
     
     napi_get_named_property(env, args[0], "width", &widthVal);
     napi_get_named_property(env, args[0], "height", &heightVal);
     napi_get_named_property(env, args[0], "title", &titleVal);
+    if (napi_get_named_property(env, args[0], "transparent", &transparentVal) == napi_ok) {
+        napi_get_value_bool(env, transparentVal, &transparent);
+    }
     
     napi_get_value_int32(env, widthVal, &width);
     napi_get_value_int32(env, heightVal, &height);
@@ -379,7 +400,8 @@ static napi_value CreateOverlayWindow(napi_env env, napi_callback_info info) {
     // Create Metal window
     MetalWindowWrapper *wrapper = [[MetalWindowWrapper alloc] initWithWidth:width
                                                                       height:height
-                                                                       title:[NSString stringWithUTF8String:title]];
+                                                                       title:[NSString stringWithUTF8String:title]
+                                                                 transparent:transparent ? YES : NO];
     
     if (!wrapper) {
         napi_throw_error(env, nullptr, "Failed to create Metal window");
@@ -615,6 +637,23 @@ static napi_value SetDebugMode(napi_env env, napi_callback_info info) {
     return result;
 }
 
+static napi_value IsOverlayTransparent(napi_env env, napi_callback_info info) {
+    size_t argc = 1;
+    napi_value args[1];
+    napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
+
+    void *data = nullptr;
+    napi_value result;
+    BOOL transparent = NO;
+    if (argc >= 1 &&
+        napi_get_value_external(env, args[0], &data) == napi_ok && data) {
+        MetalWindowWrapper *wrapper = (__bridge MetalWindowWrapper *)data;
+        transparent = [wrapper isTransparent];
+    }
+    napi_get_boolean(env, transparent ? true : false, &result);
+    return result;
+}
+
 // Module initialization
 static napi_value Init(napi_env env, napi_value exports) {
     napi_status status;
@@ -655,6 +694,15 @@ static napi_value Init(napi_env env, napi_value exports) {
     if (status != napi_ok) return nullptr;
     status = napi_set_named_property(env, exports, "renderFrame", fn);
     if (status != napi_ok) return nullptr;
+    
+    status = napi_create_function(env, nullptr, 0, IsOverlayTransparent, nullptr, &fn);
+    if (status != napi_ok) return nullptr;
+    status = napi_set_named_property(env, exports, "isOverlayTransparent", fn);
+    if (status != napi_ok) return nullptr;
+    
+    // Note: no presentFrame here. MTKView drives its own display link
+    // (paused = NO, preferredFramesPerSecond = 60), so it already presents
+    // continuously without being pumped from JavaScript.
     
     status = napi_create_function(env, nullptr, 0, DestroyOverlayWindow, nullptr, &fn);
     if (status != napi_ok) return nullptr;

--- a/native/windows-overlay.cpp
+++ b/native/windows-overlay.cpp
@@ -9,7 +9,15 @@
 
 #include <windows.h>
 #include <GL/gl.h>
+#include <dwmapi.h>
+#include <d3d11.h>
+#include <dxgi1_2.h>
+#include <dcomp.h>
 #pragma comment(lib, "opengl32.lib")
+#pragma comment(lib, "dwmapi.lib")
+#pragma comment(lib, "d3d11.lib")
+#pragma comment(lib, "dxgi.lib")
+#pragma comment(lib, "dcomp.lib")
 #pragma comment(lib, "gdi32.lib")
 #pragma comment(lib, "user32.lib")
 
@@ -29,6 +37,123 @@ static bool g_debugMode = false;
 #define GL_CLAMP_TO_EDGE 0x812F
 #endif
 
+// WGL_ARB_pixel_format constants (not in the SDK GL/gl.h).
+#define WGL_DRAW_TO_WINDOW_ARB     0x2001
+#define WGL_ACCELERATION_ARB       0x2003
+#define WGL_SUPPORT_OPENGL_ARB     0x2010
+#define WGL_DOUBLE_BUFFER_ARB      0x2011
+#define WGL_PIXEL_TYPE_ARB         0x2013
+#define WGL_COLOR_BITS_ARB         0x2014
+#define WGL_ALPHA_BITS_ARB         0x201B
+#define WGL_DEPTH_BITS_ARB         0x2022
+#define WGL_FULL_ACCELERATION_ARB  0x2027
+#define WGL_TYPE_RGBA_ARB          0x202B
+
+// SetWindowCompositionAttribute: undocumented, but it is the route most apps
+// actually use for per-pixel alpha, and it takes a different DWM path from
+// DwmEnableBlurBehindWindow -- which measured opaque on a machine where
+// Chromium transparent windows composite fine.
+enum ACCENT_STATE {
+    ACCENT_DISABLED = 0,
+    ACCENT_ENABLE_GRADIENT = 1,
+    ACCENT_ENABLE_TRANSPARENTGRADIENT = 2,
+    ACCENT_ENABLE_BLURBEHIND = 3,
+};
+struct ACCENT_POLICY {
+    ACCENT_STATE AccentState;
+    DWORD AccentFlags;
+    DWORD GradientColor;
+    DWORD AnimationId;
+};
+enum WINDOWCOMPOSITIONATTRIB { WCA_ACCENT_POLICY = 19 };
+struct WINDOWCOMPOSITIONATTRIBDATA {
+    WINDOWCOMPOSITIONATTRIB Attrib;
+    PVOID pvData;
+    SIZE_T cbData;
+};
+typedef BOOL (WINAPI *PFNSETWINDOWCOMPOSITIONATTRIBUTE)(HWND, WINDOWCOMPOSITIONATTRIBDATA*);
+
+static bool EnableAccentTransparency(HWND hwnd) {
+    HMODULE user32 = GetModuleHandleA("user32.dll");
+    if (!user32) return false;
+    auto setAttr = (PFNSETWINDOWCOMPOSITIONATTRIBUTE)
+        GetProcAddress(user32, "SetWindowCompositionAttribute");
+    if (!setAttr) return false;
+    ACCENT_POLICY policy = {};
+    policy.AccentState = ACCENT_ENABLE_TRANSPARENTGRADIENT;
+    policy.AccentFlags = 2;
+    policy.GradientColor = 0x00000000;  // fully transparent
+    WINDOWCOMPOSITIONATTRIBDATA data = { WCA_ACCENT_POLICY, &policy, sizeof(policy) };
+    return setAttr(hwnd, &data) != FALSE;
+}
+
+typedef BOOL (WINAPI *PFNWGLCHOOSEPIXELFORMATARBPROC)(
+    HDC, const int*, const FLOAT*, UINT, int*, UINT*);
+
+// Picks a hardware-accelerated RGBA format with a real alpha channel, which is
+// what DWM needs before it will composite this window per-pixel. Returns 0 if
+// the ARB extension is unavailable, so the caller can fall back.
+static int ChooseAlphaPixelFormat(HDC targetDC) {
+    // A pixel format can only be set once per window, so the lookup needs its
+    // own throwaway window and context.
+    WNDCLASSEX dummyClass = {};
+    dummyClass.cbSize = sizeof(WNDCLASSEX);
+    dummyClass.lpfnWndProc = DefWindowProc;
+    dummyClass.hInstance = GetModuleHandle(nullptr);
+    dummyClass.lpszClassName = "SteamOverlayGLProbe";
+    static bool dummyRegistered = false;
+    if (!dummyRegistered) { RegisterClassEx(&dummyClass); dummyRegistered = true; }
+
+    HWND dummyWnd = CreateWindowEx(0, "SteamOverlayGLProbe", "", WS_POPUP,
+                                   0, 0, 1, 1, nullptr, nullptr,
+                                   GetModuleHandle(nullptr), nullptr);
+    if (!dummyWnd) return 0;
+
+    int chosen = 0;
+    HDC dummyDC = GetDC(dummyWnd);
+    if (dummyDC) {
+        PIXELFORMATDESCRIPTOR basic = {};
+        basic.nSize = sizeof(basic);
+        basic.nVersion = 1;
+        basic.dwFlags = PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER;
+        basic.iPixelType = PFD_TYPE_RGBA;
+        basic.cColorBits = 32;
+        basic.cAlphaBits = 8;
+        int basicFormat = ChoosePixelFormat(dummyDC, &basic);
+        if (basicFormat && SetPixelFormat(dummyDC, basicFormat, &basic)) {
+            HGLRC dummyCtx = wglCreateContext(dummyDC);
+            if (dummyCtx && wglMakeCurrent(dummyDC, dummyCtx)) {
+                auto wglChoosePixelFormatARB =
+                    (PFNWGLCHOOSEPIXELFORMATARBPROC)wglGetProcAddress("wglChoosePixelFormatARB");
+                if (wglChoosePixelFormatARB) {
+                    const int attribs[] = {
+                        WGL_DRAW_TO_WINDOW_ARB, GL_TRUE,
+                        WGL_SUPPORT_OPENGL_ARB, GL_TRUE,
+                        WGL_DOUBLE_BUFFER_ARB,  GL_TRUE,
+                        WGL_ACCELERATION_ARB,   WGL_FULL_ACCELERATION_ARB,
+                        WGL_PIXEL_TYPE_ARB,     WGL_TYPE_RGBA_ARB,
+                        WGL_COLOR_BITS_ARB,     32,
+                        WGL_ALPHA_BITS_ARB,     8,
+                        WGL_DEPTH_BITS_ARB,     24,
+                        0
+                    };
+                    int formats[16];
+                    UINT count = 0;
+                    if (wglChoosePixelFormatARB(targetDC, attribs, nullptr, 16, formats, &count)
+                        && count > 0) {
+                        chosen = formats[0];
+                    }
+                }
+                wglMakeCurrent(nullptr, nullptr);
+            }
+            if (dummyCtx) wglDeleteContext(dummyCtx);
+        }
+        ReleaseDC(dummyWnd, dummyDC);
+    }
+    DestroyWindow(dummyWnd);
+    return chosen;
+}
+
 // OpenGL Overlay Window class
 class GLOverlayWindow {
 public:
@@ -43,6 +168,54 @@ public:
     int width = 0;
     int height = 0;
     bool isDestroyed = false;
+
+    // Transparent mode: the window presents an empty, fully-transparent frame
+    // instead of a copy of the game. Steam still draws its overlay into it on
+    // the hooked SwapBuffers, so the overlay and its notifications appear,
+    // while the real game window shows through everywhere Steam did not draw.
+    // That removes the need to mirror frames at all -- and with it the 30fps
+    // ceiling that mirroring imposes on what the player sees.
+    bool transparent = false;
+
+    // Transparency is done with D3D11 + DirectComposition, not WGL.
+    //
+    // WGL cannot do it: measured on a GeForce/Quadro machine where Chromium
+    // transparent windows composite correctly, a GL window stayed pure black
+    // through DwmEnableBlurBehindWindow, PFD_SUPPORT_COMPOSITION,
+    // wglChoosePixelFormatARB with a real alpha format,
+    // DwmExtendFrameIntoClientArea, and SetWindowCompositionAttribute -- every
+    // one of which reported success. NVIDIA's GL driver simply does not
+    // cooperate with DWM per-pixel alpha. DirectComposition is what Chromium
+    // uses, and Steam hooks DXGI at least as readily as it hooks OpenGL.
+    //
+    // Null unless transparency was requested AND the D3D path came up; the
+    // WGL path below is kept as the fallback so a machine that cannot do this
+    // still gets an overlay.
+    ID3D11Device* d3dDevice = nullptr;
+    ID3D11DeviceContext* d3dContext = nullptr;
+    IDXGISwapChain1* dxgiSwapChain = nullptr;
+    ID3D11RenderTargetView* d3dRenderTarget = nullptr;
+    IDCompositionDevice* dcompDevice = nullptr;
+    IDCompositionTarget* dcompTarget = nullptr;
+    IDCompositionVisual* dcompVisual = nullptr;
+    bool usingD3D11 = false;
+    // Size the swapchain buffers were last allocated at. setFrame is called on
+    // every geometry sync -- which for some callers is every frame -- and
+    // ResizeBuffers there unconditionally tears down and reallocates the back
+    // buffers, which reads on screen as heavy flicker.
+    int swapWidth = 0;
+    int swapHeight = 0;
+
+    // The game window this overlay belongs to, when the caller supplies it.
+    //
+    // Passing it as CreateWindowEx s hWndParent makes this an OWNED window,
+    // which is the correct z-order: always above its owner, hidden and
+    // minimised with it, and -- crucially -- never above unrelated
+    // applications. WS_EX_TOPMOST alone floats the overlay over every other
+    // window on the desktop even while the game sits unfocused in the
+    // background, so Steam s overlay would paint over whatever the player had
+    // switched to.
+    HWND ownerHwnd = nullptr;
     std::mutex renderMutex;
     
     static LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
@@ -60,7 +233,10 @@ public:
         }
     }
     
-    bool init(int w, int h, const char* title) {
+    bool init(int w, int h, const char* title, bool wantTransparent = false,
+              HWND owner = nullptr) {
+        transparent = wantTransparent;
+        ownerHwnd = owner;
         width = w;
         height = h;
         
@@ -84,13 +260,15 @@ public:
         
         // Create borderless window
         // Note: Don't use WS_EX_LAYERED - it's incompatible with OpenGL rendering
+        // Only fall back to TOPMOST when there is no owner to sit above.
         hwnd = CreateWindowEx(
-            WS_EX_TOPMOST | WS_EX_NOACTIVATE,
+            (owner ? 0 : WS_EX_TOPMOST) | WS_EX_NOACTIVATE |
+                (wantTransparent ? WS_EX_NOREDIRECTIONBITMAP : 0),
             "SteamOverlayWindowGL",
             title,
             WS_POPUP,
             100, 100, w, h,
-            nullptr, nullptr,
+            owner, nullptr,
             GetModuleHandle(nullptr),
             nullptr
         );
@@ -98,6 +276,45 @@ public:
         if (!hwnd) {
             OverlayLogError("Failed to create window");
             return false;
+        }
+
+        // Per-pixel alpha. A blur-behind with an EMPTY region asks DWM to
+        // composite this window using its alpha channel without actually
+        // blurring anything -- the standard way to get a transparent
+        // hardware-accelerated GL window. Layered windows (WS_EX_LAYERED +
+        // UpdateLayeredWindow) cannot do this with an OpenGL context.
+        if (transparent && initD3D11()) {
+            // D3D11 + DComp is up; the WGL context below is not needed.
+            OverlayLog("OpenGL overlay window created: %dx%d (D3D11 transparent)", width, height);
+            return true;
+        }
+        if (transparent) {
+            OverlayLogError("D3D11 transparency unavailable; falling back to WGL "
+                            "(the overlay will work but will not be transparent)");
+        }
+        if (transparent) {
+            DWM_BLURBEHIND bb = {};
+            bb.dwFlags = DWM_BB_ENABLE | DWM_BB_BLURREGION;
+            bb.fEnable = TRUE;
+            bb.hRgnBlur = CreateRectRgn(0, 0, -1, -1);
+            HRESULT hr = DwmEnableBlurBehindWindow(hwnd, &bb);
+
+            // Belt and braces: extending the frame into the whole client area
+            // ("sheet of glass") is the other documented route to per-pixel
+            // alpha, and some drivers honour it where blur-behind alone is
+            // ignored. Harmless alongside it.
+            MARGINS margins = { -1, -1, -1, -1 };
+            DwmExtendFrameIntoClientArea(hwnd, &margins);
+
+            OverlayLog("Transparent mode: accent transparency %s",
+                       EnableAccentTransparency(hwnd) ? "applied" : "UNAVAILABLE");
+            if (bb.hRgnBlur) DeleteObject(bb.hRgnBlur);
+            if (FAILED(hr)) {
+                OverlayLogError("DwmEnableBlurBehindWindow failed (0x%08lX); "
+                                "the overlay will be opaque", (unsigned long)hr);
+            } else {
+                OverlayLog("Transparent mode: DWM alpha compositing enabled");
+            }
         }
         
         // Get device context
@@ -112,13 +329,28 @@ public:
         pfd.nSize = sizeof(PIXELFORMATDESCRIPTOR);
         pfd.nVersion = 1;
         pfd.dwFlags = PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER;
+        if (transparent) {
+            // Required for DWM to composite this window per-pixel. Without it
+            // the alpha channel is ignored and the window renders opaque.
+            pfd.dwFlags |= PFD_SUPPORT_COMPOSITION;
+        }
         pfd.iPixelType = PFD_TYPE_RGBA;
         pfd.cColorBits = 32;
         pfd.cAlphaBits = 8;
         pfd.cDepthBits = 24;
         pfd.iLayerType = PFD_MAIN_PLANE;
         
-        int pixelFormat = ChoosePixelFormat(hdc, &pfd);
+        int pixelFormat = 0;
+        if (transparent) {
+            pixelFormat = ChooseAlphaPixelFormat(hdc);
+            if (pixelFormat) {
+                OverlayLog("Transparent mode: ARB alpha pixel format %d", pixelFormat);
+            } else {
+                OverlayLogError("wglChoosePixelFormatARB unavailable; "
+                                "falling back to a format DWM will render opaque");
+            }
+        }
+        if (!pixelFormat) pixelFormat = ChoosePixelFormat(hdc, &pfd);
         if (!pixelFormat) {
             OverlayLogError("Failed to choose pixel format");
             return false;
@@ -151,6 +383,112 @@ public:
         return true;
     }
     
+    // Builds the D3D11 device, a composition swapchain and the DComp visual
+    // tree that presents it. Returns false on any failure so init() can fall
+    // back to WGL rather than leaving the player with no overlay.
+    bool initD3D11() {
+        D3D_FEATURE_LEVEL levels[] = {
+            D3D_FEATURE_LEVEL_11_1, D3D_FEATURE_LEVEL_11_0,
+            D3D_FEATURE_LEVEL_10_1, D3D_FEATURE_LEVEL_10_0,
+            D3D_FEATURE_LEVEL_9_3,  D3D_FEATURE_LEVEL_9_2,
+            D3D_FEATURE_LEVEL_9_1,
+        };
+        // BGRA_SUPPORT is REQUIRED for DirectComposition interop.
+        UINT flags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
+        D3D_FEATURE_LEVEL got;
+        HRESULT hr = D3D11CreateDevice(nullptr, D3D_DRIVER_TYPE_HARDWARE, nullptr,
+                                       flags, levels, ARRAYSIZE(levels),
+                                       D3D11_SDK_VERSION, &d3dDevice, &got, &d3dContext);
+        if (FAILED(hr)) {
+            // WARP ships with Windows, so this is the "no usable GPU driver"
+            // path rather than a dead end.
+            OverlayLog("D3D11 hardware device failed (0x%08lX); trying WARP", (unsigned long)hr);
+            hr = D3D11CreateDevice(nullptr, D3D_DRIVER_TYPE_WARP, nullptr,
+                                   flags, levels, ARRAYSIZE(levels),
+                                   D3D11_SDK_VERSION, &d3dDevice, &got, &d3dContext);
+        }
+        if (FAILED(hr)) { OverlayLogError("D3D11CreateDevice failed (0x%08lX)", (unsigned long)hr); return false; }
+
+        IDXGIDevice* dxgiDevice = nullptr;
+        if (FAILED(d3dDevice->QueryInterface(__uuidof(IDXGIDevice), (void**)&dxgiDevice))) return false;
+
+        IDXGIAdapter* adapter = nullptr;
+        IDXGIFactory2* factory = nullptr;
+        bool ok = false;
+        if (SUCCEEDED(dxgiDevice->GetAdapter(&adapter)) &&
+            SUCCEEDED(adapter->GetParent(__uuidof(IDXGIFactory2), (void**)&factory))) {
+            DXGI_SWAP_CHAIN_DESC1 desc = {};
+            desc.Width = width;
+            desc.Height = height;
+            desc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+            desc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+            desc.BufferCount = 2;
+            desc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL;
+            // The whole point: premultiplied alpha is what lets DWM show what
+            // is behind wherever Steam has not drawn.
+            desc.AlphaMode = DXGI_ALPHA_MODE_PREMULTIPLIED;
+            desc.SampleDesc.Count = 1;
+            hr = factory->CreateSwapChainForComposition(d3dDevice, &desc, nullptr, &dxgiSwapChain);
+            if (FAILED(hr)) OverlayLogError("CreateSwapChainForComposition failed (0x%08lX)", (unsigned long)hr);
+            else ok = true;
+        }
+        if (factory) factory->Release();
+        if (adapter) adapter->Release();
+
+        if (ok) {
+            hr = DCompositionCreateDevice(dxgiDevice, __uuidof(IDCompositionDevice), (void**)&dcompDevice);
+            if (SUCCEEDED(hr) &&
+                SUCCEEDED(dcompDevice->CreateTargetForHwnd(hwnd, TRUE, &dcompTarget)) &&
+                SUCCEEDED(dcompDevice->CreateVisual(&dcompVisual)) &&
+                SUCCEEDED(dcompVisual->SetContent(dxgiSwapChain)) &&
+                SUCCEEDED(dcompTarget->SetRoot(dcompVisual)) &&
+                SUCCEEDED(dcompDevice->Commit())) {
+                OverlayLog("Transparent mode: D3D11 + DirectComposition ready (feature level 0x%04X)", got);
+            } else {
+                OverlayLogError("DirectComposition setup failed (0x%08lX)", (unsigned long)hr);
+                ok = false;
+            }
+        }
+        dxgiDevice->Release();
+        if (ok) ok = createD3DRenderTarget();
+        if (ok) { swapWidth = width; swapHeight = height; }
+        usingD3D11 = ok;
+        return ok;
+    }
+
+    bool createD3DRenderTarget() {
+        if (d3dRenderTarget) { d3dRenderTarget->Release(); d3dRenderTarget = nullptr; }
+        ID3D11Texture2D* backBuffer = nullptr;
+        if (FAILED(dxgiSwapChain->GetBuffer(0, __uuidof(ID3D11Texture2D), (void**)&backBuffer))) return false;
+        HRESULT hr = d3dDevice->CreateRenderTargetView(backBuffer, nullptr, &d3dRenderTarget);
+        backBuffer->Release();
+        return SUCCEEDED(hr);
+    }
+
+    // Clears to fully transparent and presents. Steam hooks Present, so its
+    // overlay is drawn between the clear and the flip -- everything it does
+    // not touch stays transparent and the real window shows through.
+    void presentD3D11() {
+        if (!usingD3D11 || !d3dContext || !dxgiSwapChain || !d3dRenderTarget) return;
+        const float clear[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+        d3dContext->OMSetRenderTargets(1, &d3dRenderTarget, nullptr);
+        d3dContext->ClearRenderTargetView(d3dRenderTarget, clear);
+        dxgiSwapChain->Present(1, 0);
+    }
+
+    void resizeD3D11(int w, int h) {
+        if (!usingD3D11 || !dxgiSwapChain || w <= 0 || h <= 0) return;
+        if (w == swapWidth && h == swapHeight) return;  // nothing changed
+        if (d3dRenderTarget) { d3dRenderTarget->Release(); d3dRenderTarget = nullptr; }
+        if (d3dContext) d3dContext->OMSetRenderTargets(0, nullptr, nullptr);
+        HRESULT hr = dxgiSwapChain->ResizeBuffers(0, w, h, DXGI_FORMAT_UNKNOWN, 0);
+        if (FAILED(hr)) { OverlayLogError("ResizeBuffers failed (0x%08lX)", (unsigned long)hr); return; }
+        swapWidth = w;
+        swapHeight = h;
+        createD3DRenderTarget();
+        OverlayLog("Resized composition swapchain to %dx%d", w, h);
+    }
+
     void initGL() {
         // Set up basic OpenGL state
         glEnable(GL_TEXTURE_2D);
@@ -179,7 +517,7 @@ public:
         if (hwnd) {
             OverlayLog("Showing overlay window");
             ShowWindow(hwnd, SW_SHOWNOACTIVATE);
-            SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0, 
+            SetWindowPos(hwnd, ownerHwnd ? HWND_TOP : HWND_TOPMOST, 0, 0, 0, 0, 
                 SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_SHOWWINDOW);
             UpdateWindow(hwnd);
         }
@@ -216,8 +554,11 @@ public:
             width = physW;
             height = physH;
             
-            SetWindowPos(hwnd, HWND_TOPMOST, physX, physY, physW, physH, 
+            SetWindowPos(hwnd, ownerHwnd ? HWND_TOP : HWND_TOPMOST, physX, physY, physW, physH, 
                 SWP_NOACTIVATE | SWP_SHOWWINDOW);
+            
+            // The composition swapchain has its own buffers to resize.
+            if (usingD3D11) resizeD3D11(physW, physH);
             
             // Update OpenGL viewport
             if (hglrc && hdc) {
@@ -238,6 +579,10 @@ public:
         if (isDestroyed) return;
         
         std::lock_guard<std::mutex> lock(renderMutex);
+        
+        // Transparent mode ignores the pixels entirely: a caller that keeps
+        // sending frames costs nothing but still drives the present.
+        if (transparent) { presentEmpty(); return; }
         
         if (!hglrc || !hdc) return;
         if (!wglMakeCurrent(hdc, hglrc)) return;
@@ -287,9 +632,47 @@ public:
         SwapBuffers(hdc);
     }
     
+    // Presents an empty transparent frame. Steam hooks SwapBuffers, so this
+    // is what gives it the chance to draw the overlay and its notifications.
+    // No texture, no upload, and nothing for the caller to capture.
+    //
+    // Caller must hold renderMutex -- this touches the GL context.
+    void presentEmpty() {
+        if (isDestroyed) return;
+        if (usingD3D11) { presentD3D11(); return; }
+        if (!hdc || !hglrc) return;
+        wglMakeCurrent(hdc, hglrc);
+        glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+        glClear(GL_COLOR_BUFFER_BIT);
+        SwapBuffers(hdc);
+    }
+
+    // Locked wrapper around presentEmpty for callers outside the class.
+    // True only when transparency was requested AND actually achieved -- i.e.
+    // the D3D11 + DirectComposition path came up. False on the WGL fallback,
+    // where the window is opaque.
+    bool isTransparent() const { return transparent && usingD3D11; }
+
+    void present() {
+        if (isDestroyed) return;
+        std::lock_guard<std::mutex> lock(renderMutex);
+        presentEmpty();
+    }
+
     void destroy() {
         if (isDestroyed) return;
         isDestroyed = true;
+
+        // Reverse order of creation. Safe when the D3D path was never taken:
+        // every one of these is null then.
+        if (dcompTarget) { dcompTarget->SetRoot(nullptr); dcompTarget->Release(); dcompTarget = nullptr; }
+        if (dcompVisual) { dcompVisual->Release(); dcompVisual = nullptr; }
+        if (dcompDevice) { dcompDevice->Commit(); dcompDevice->Release(); dcompDevice = nullptr; }
+        if (d3dRenderTarget) { d3dRenderTarget->Release(); d3dRenderTarget = nullptr; }
+        if (dxgiSwapChain) { dxgiSwapChain->Release(); dxgiSwapChain = nullptr; }
+        if (d3dContext) { d3dContext->ClearState(); d3dContext->Release(); d3dContext = nullptr; }
+        if (d3dDevice) { d3dDevice->Release(); d3dDevice = nullptr; }
+        usingD3D11 = false;
         
         OverlayLog("Destroying OpenGL overlay...");
         
@@ -336,10 +719,21 @@ static napi_value CreateOverlayWindow(napi_env env, napi_callback_info info) {
     }
     
     // Get options
-    napi_value widthVal, heightVal, titleVal;
+    napi_value widthVal, heightVal, titleVal, transparentVal;
     napi_get_named_property(env, args[0], "width", &widthVal);
     napi_get_named_property(env, args[0], "height", &heightVal);
     napi_get_named_property(env, args[0], "title", &titleVal);
+    napi_get_named_property(env, args[0], "transparent", &transparentVal);
+    napi_value ownerVal;
+    napi_get_named_property(env, args[0], "ownerHwnd", &ownerVal);
+
+    // Opt-in, so existing callers are unaffected.
+    bool transparent = false;
+    napi_valuetype transparentType;
+    if (napi_typeof(env, transparentVal, &transparentType) == napi_ok &&
+        transparentType == napi_boolean) {
+        napi_get_value_bool(env, transparentVal, &transparent);
+    }
     
     int width, height;
     napi_get_value_int32(env, widthVal, &width);
@@ -351,7 +745,22 @@ static napi_value CreateOverlayWindow(napi_env env, napi_callback_info info) {
     
     // Create window
     GLOverlayWindow* window = new GLOverlayWindow();
-    if (!window->init(width, height, title)) {
+    // browserWindow.getNativeWindowHandle() read as a 64-bit integer.
+    HWND owner = nullptr;
+    napi_valuetype ownerType;
+    if (napi_typeof(env, ownerVal, &ownerType) == napi_ok && ownerType == napi_bigint) {
+        int64_t raw = 0; bool lossless = false;
+        if (napi_get_value_bigint_int64(env, ownerVal, &raw, &lossless) == napi_ok && raw != 0) {
+            owner = (HWND)(intptr_t)raw;
+        }
+    } else if (ownerType == napi_number) {
+        double raw = 0;
+        if (napi_get_value_double(env, ownerVal, &raw) == napi_ok && raw != 0) {
+            owner = (HWND)(intptr_t)(int64_t)raw;
+        }
+    }
+
+    if (!window->init(width, height, title, transparent, owner)) {
         delete window;
         napi_throw_error(env, nullptr, "Failed to create overlay window");
         return nullptr;
@@ -362,6 +771,35 @@ static napi_value CreateOverlayWindow(napi_env env, napi_callback_info info) {
     status = napi_create_external(env, window, nullptr, nullptr, &external);
     
     return external;
+}
+
+static napi_value IsOverlayTransparent(napi_env env, napi_callback_info info) {
+    size_t argc = 1;
+    napi_value args[1];
+    napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
+
+    GLOverlayWindow* window = nullptr;
+    napi_value result;
+    bool transparent = false;
+    if (argc >= 1 &&
+        napi_get_value_external(env, args[0], (void**)&window) == napi_ok && window) {
+        transparent = window->isTransparent();
+    }
+    napi_get_boolean(env, transparent, &result);
+    return result;
+}
+
+static napi_value PresentFrame(napi_env env, napi_callback_info info) {
+    size_t argc = 1;
+    napi_value args[1];
+    napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
+
+    GLOverlayWindow* window;
+    if (napi_get_value_external(env, args[0], (void**)&window) != napi_ok || !window) {
+        return nullptr;
+    }
+    window->present();
+    return nullptr;
 }
 
 static napi_value ShowOverlayWindow(napi_env env, napi_callback_info info) {
@@ -473,6 +911,8 @@ static napi_value Init(napi_env env, napi_value exports) {
         { "hideOverlayWindow", nullptr, HideOverlayWindow, nullptr, nullptr, nullptr, napi_default, nullptr },
         { "setOverlayFrame", nullptr, SetOverlayWindowFrame, nullptr, nullptr, nullptr, napi_default, nullptr },
         { "renderFrame", nullptr, RenderFrame, nullptr, nullptr, nullptr, napi_default, nullptr },
+        { "presentFrame", nullptr, PresentFrame, nullptr, nullptr, nullptr, napi_default, nullptr },
+        { "isOverlayTransparent", nullptr, IsOverlayTransparent, nullptr, nullptr, nullptr, napi_default, nullptr },
         { "destroyOverlayWindow", nullptr, DestroyOverlayWindow, nullptr, nullptr, nullptr, napi_default, nullptr },
         { "setDebugMode", nullptr, SetDebugMode, nullptr, nullptr, nullptr, napi_default, nullptr }
     };

--- a/native/windows-overlay.cpp
+++ b/native/windows-overlay.cpp
@@ -220,6 +220,31 @@ public:
     
     static LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
         switch (msg) {
+            case WM_MOUSEACTIVATE: {
+                // Hand activation to the game window.
+                //
+                // WS_EX_NOACTIVATE told Windows not to change activation when
+                // this window was clicked, and nothing then passed that decision
+                // on to the owner -- so clicking the game content left focus
+                // wherever it already was, and the player could not type. The
+                // title bar still worked, because the overlay covers the content
+                // area only, which is what made this look like a focus bug rather
+                // than an overlay one.
+                //
+                // HTTRANSPARENT below is not enough on its own: it routes the
+                // mouse *message* to the window beneath, but the activation
+                // decision is made against the window the hit test landed on.
+                // Verified by parking this window off-screen, which fixed the
+                // focus and removed the overlay -- so the window is both
+                // necessary and the cause. WS_EX_TRANSPARENT alone did not fix
+                // it, which is what ruled out hit-testing as the explanation.
+                //
+                // With no owner, this still declines activation, matching the
+                // previous behaviour of the style it replaces.
+                HWND owner = GetWindow(hwnd, GW_OWNER);
+                if (owner) SetForegroundWindow(owner);
+                return MA_NOACTIVATE;
+            }
             case WM_NCHITTEST:
                 // Return HTTRANSPARENT to make clicks pass through to window behind
                 return HTTRANSPARENT;
@@ -262,7 +287,7 @@ public:
         // Note: Don't use WS_EX_LAYERED - it's incompatible with OpenGL rendering
         // Only fall back to TOPMOST when there is no owner to sit above.
         hwnd = CreateWindowEx(
-            (owner ? 0 : WS_EX_TOPMOST) | WS_EX_NOACTIVATE |
+            (owner ? 0 : WS_EX_TOPMOST) |
                 (wantTransparent ? WS_EX_NOREDIRECTIONBITMAP : 0),
             "SteamOverlayWindowGL",
             title,

--- a/src/internal/SteamOverlay.ts
+++ b/src/internal/SteamOverlay.ts
@@ -36,10 +36,29 @@ import { SteamLogger } from "./SteamLogger";
  * steam.addElectronSteamOverlay(win);
  * ```
  */
+/**
+ * The platform window handle behind a BrowserWindow, or undefined if it cannot
+ * be read. Never throws: an overlay is optional, and failing to read a handle
+ * must not take the host application down with it.
+ */
+function readWindowHandle(browserWindow: any): bigint | undefined {
+  try {
+    const handle = browserWindow?.getNativeWindowHandle?.();
+    if (!handle || handle.length < 8) return undefined;
+    return handle.readBigUInt64LE(0);
+  } catch {
+    return undefined;
+  }
+}
+
 export class SteamOverlay {
   private nativeModule: any = null;
   private isInitialized: boolean = false;
   private overlayWindow: any = null;
+  /** Whether the overlay window is genuinely transparent -- see isTransparent(). */
+  private transparentActive = false;
+  /** Drives Present in transparent mode, where there is no frame subscription. */
+  private presentTimer: any = null;
 
   constructor() {
     // Load native overlay module for the current platform
@@ -148,6 +167,27 @@ export class SteamOverlay {
       title?: string;
       fps?: number;
       vsync?: boolean;
+      /**
+       * Present an empty TRANSPARENT frame instead of mirroring the window,
+       * and let Steam draw into it.
+       *
+       * The default (mirroring) copies the window via beginFrameSubscription,
+       * which is capped at 30fps on a non-offscreen window -- and since the
+       * overlay window sits on top, that cap is what the user sees. In
+       * transparent mode nothing is copied at all: the real window shows
+       * through at its own framerate, and Steam draws its overlay,
+       * notifications and FPS counter on top of it.
+       *
+       * What has to be available differs by platform: D3D11 +
+       * DirectComposition on Windows, a depth-32 ARGB visual plus a running
+       * compositing manager on Linux, and Metal on macOS (where the layer is
+       * already configured for per-pixel alpha).
+       *
+       * Where it is not available this falls back to the mirroring path,
+       * silently -- isTransparent() reports which one is in effect. Leave
+       * this unset and nothing changes: mirroring behaves as before.
+       */
+      transparent?: boolean;
     },
   ): boolean {
     if (!this.isInitialized || !this.nativeModule) {
@@ -170,6 +210,21 @@ export class SteamOverlay {
       const contentBounds = browserWindow.getContentBounds();
       const fps = options?.fps || 60;
 
+      // A transparent overlay window is on screen permanently, so it must not
+      // be WS_EX_TOPMOST -- that would paint it over whatever the user
+      // switches to while the game sits in the background. Passing the game's
+      // HWND as CreateWindowEx's hWndParent makes it an OWNED window instead:
+      // always above its owner, hidden and minimised with it, and never above
+      // unrelated applications.
+      //
+      // Derived here rather than asked of the caller: we already hold the
+      // BrowserWindow, so making them extract the handle from it would be
+      // asking for something we can read ourselves.
+      const ownerHwnd =
+        options?.transparent === true && process.platform === "win32"
+          ? readWindowHandle(browserWindow)
+          : undefined;
+
       // Create overlay window matching Electron's content area (not full window)
       const overlayWindowOptions = {
         width: contentBounds.width,
@@ -177,6 +232,8 @@ export class SteamOverlay {
         title: options?.title || "Electron Steam App",
         fps: fps,
         vsync: options?.vsync !== false,
+        transparent: options?.transparent === true,
+        ownerHwnd: ownerHwnd,
       };
 
       this.overlayWindow =
@@ -185,6 +242,21 @@ export class SteamOverlay {
       if (!this.overlayWindow) {
         SteamLogger.error("[Steam Overlay] Failed to create overlay window");
         return false;
+      }
+
+      // Requesting transparency is not the same as getting it: the native side
+      // falls back to an opaque window when D3D11 or DirectComposition are
+      // unavailable. Ask what actually happened.
+      this.transparentActive =
+        options?.transparent === true &&
+        typeof this.nativeModule.isOverlayTransparent === "function" &&
+        this.nativeModule.isOverlayTransparent(this.overlayWindow) === true;
+
+      if (options?.transparent === true && !this.transparentActive) {
+        SteamLogger.error(
+          "[Steam Overlay] Transparency was requested but is unavailable; " +
+            "falling back to mirroring. The overlay window is OPAQUE.",
+        );
       }
 
       // On Linux: tag the Electron window with STEAM_GAME and wire up input forwarding
@@ -250,8 +322,36 @@ export class SteamOverlay {
         }
       };
 
-      SteamLogger.debug(`[Steam Overlay] Starting frame subscription at ${fps} FPS`);
-      browserWindow.webContents.beginFrameSubscription(false, frameSubscription);
+      if (this.transparentActive) {
+        // Nothing to capture: the window presents empty transparent frames and
+        // Steam draws into them. This is what removes the 30fps ceiling that
+        // beginFrameSubscription imposes on a non-offscreen window, along with
+        // the per-frame getBitmap() readback.
+        if (typeof this.nativeModule.presentFrame === "function") {
+          const interval = Math.max(1, Math.round(1000 / fps));
+          this.presentTimer = setInterval(() => {
+            if (!this.overlayWindow || !this.nativeModule) return;
+            if (browserWindow.isDestroyed && browserWindow.isDestroyed()) return;
+            try {
+              this.nativeModule.presentFrame(this.overlayWindow);
+            } catch {
+              /* a failed present must never take the app down */
+            }
+          }, interval);
+          SteamLogger.debug(
+            `[Steam Overlay] Transparent mode: presenting empty frames at ${fps} FPS, no capture`,
+          );
+        } else {
+          // macOS: MTKView runs its own display link, so it is already
+          // presenting empty frames and must not also be pumped from here.
+          SteamLogger.debug(
+            "[Steam Overlay] Transparent mode: backend presents on its own, no capture",
+          );
+        }
+      } else {
+        SteamLogger.debug(`[Steam Overlay] Starting frame subscription at ${fps} FPS`);
+        browserWindow.webContents.beginFrameSubscription(false, frameSubscription);
+      }
 
       // Function to sync overlay window frame with Electron's CONTENT area
       // Overlay window is borderless, so it only covers the content, not title bar
@@ -403,7 +503,27 @@ export class SteamOverlay {
    * This is called automatically when the Electron window closes,
    * but can be called manually if needed.
    */
+  /**
+   * Whether the overlay window is genuinely transparent.
+   *
+   * Only meaningful if `transparent: true` was requested; false otherwise.
+   *
+   * Requesting `transparent: true` does not guarantee it: the native side
+   * falls back to an opaque mirroring window when D3D11 or DirectComposition
+   * are unavailable, and on platforms where transparency is unimplemented.
+   * Callers MUST branch on this rather than on what they asked for -- an
+   * opaque overlay window covers the app it sits on.
+   */
+  isTransparent(): boolean {
+    return this.transparentActive;
+  }
+
   destroyOverlayWindow(): void {
+    if (this.presentTimer) {
+      clearInterval(this.presentTimer);
+      this.presentTimer = null;
+    }
+    this.transparentActive = false;
     if (this.overlayWindow && this.nativeModule) {
       try {
         this.nativeModule.destroyOverlayWindow(this.overlayWindow);


### PR DESCRIPTION
## Description

Adds an opt-in `transparent: true` mode to `addElectronSteamOverlay`. Instead of mirroring the Electron window into the overlay window, the overlay presents an empty transparent frame and Steam draws into it, so the app shows through at its own framerate.

Fixes #64.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Performance improvement

## Related Issues

None.

## Motivation and Context

`beginFrameSubscription` is capped at 30fps on a non-offscreen window. Because the overlay window sits on top of the app, that cap becomes the framerate the user sees — a 60fps app looks like a 30fps one whenever the overlay window is visible.

I measured 30.0fps windowed, 29.9 maximised, and 30.0 with the `getBitmap()` readback removed entirely, so it's the subscription rather than the copy. `setFrameRate` is documented as a no-op outside OSR, so the `fps` option can't lift it either.

There's a second consequence: because Steam's notifications and FPS counter render *into* the overlay window, and the mirror is repainted over them from the app's own frames, they are effectively never seen.

## Changes Made

- `transparent?: boolean` option — presents an empty transparent frame instead of mirroring. Skips `beginFrameSubscription` entirely.
- `isTransparent()` — reports whether transparency actually engaged. The fallback is otherwise silent, and availability differs by platform, so there needs to be some way to tell. It is diagnostic rather than something callers have to branch on: leave `transparent` unset and it is always false.
- macOS: the Metal layer was already set up for per-pixel alpha (`opaque = NO`, clear colour alpha 0, BGRA8Unorm), so this only reports the capability and skips drawing the mirror texture. MTKView already drives its own presents, so no timer is needed there.
- Linux: adds `present()`, which clears and swaps without a texture upload, and prefers a depth-32 ARGB visual when choosing the FBConfig — `GLX_ALPHA_SIZE` is a minimum on the GL drawable and `glXChooseFBConfig` will otherwise hand back a depth-24 config, which cannot blend. The X event pump moved out of `renderFrame` into `pumpXEvents()` so `present()` can share it; without that, input forwarding and Shift+Tab would stop in transparent mode.
- Windows: gains a D3D11 + DirectComposition path, used only when `transparent` is set. WGL is untouched and still the default.
- Windows: the transparent overlay window is made an **owned** window instead of `WS_EX_TOPMOST`, so it sits above the app it belongs to rather than above every window on the desktop. It has to be — unlike the mirror, this window is on screen permanently. No new option: the owner is taken from the `BrowserWindow` already passed in, the same way the Linux path already reads `getNativeWindowHandle()`.
- `ResizeBuffers` guarded on an actual size change. `setFrame` runs on every geometry sync, which for some callers is every frame, and reallocating the swapchain at 60Hz flickers badly. Internal to the new D3D11 path — it does not touch the mirroring path.
- Documented the new options in `docs/STEAM_OVERLAY_INTEGRATION.md`.

On why Windows needs D3D11: I tried to keep it in WGL first. On a machine where Chromium's own transparent windows composite correctly, the GL overlay window stayed pure black through `DwmEnableBlurBehindWindow`, `PFD_SUPPORT_COMPOSITION`, an ARB alpha pixel format, `DwmExtendFrameIntoClientArea` and `SetWindowCompositionAttribute` — each of which reported success. What works is `WS_EX_NOREDIRECTIONBITMAP` + `CreateSwapChainForComposition` with premultiplied alpha + a DComp visual. macOS and Linux need nothing equivalent because their window systems expose per-pixel alpha directly.

## Steam API Impact

- [x] No Steam API changes

This changes the native window the overlay renders into. No Steam API bindings or wrappers are touched.

## Testing

### Test Environment
- OS: Windows 11, macOS 26.6.2 on Apple Silicon, and Ubuntu 24.04
- Node.js version: v22.23.2
- Electron version: v33.4.11
- Steam Client: Running

Three GPUs: RTX 2060 SUPER (desktop, 2560×1440 @120Hz), Quadro P1000 (laptop, 1920×1080 @60Hz), and Apple Silicon on a 120Hz ProMotion panel.

### Test Cases

- [x] Manual testing completed — Windows, macOS and Linux
- [x] Tested with Steam client running
- [ ] Unit tests pass — I did not run the repo's test scripts; they exercise Steam API surfaces this PR doesn't touch
- [ ] Integration tests pass
- [ ] Tested without Steam client

### Test Results

**Windows.** On both GPUs, with the overlay open: the app underneath ran at the panel's refresh rate rather than 30 (119fps on the 120Hz panel, which also rules out a cap at 60), frames were stable, transparency verified by sampling pixels rather than by eye, and the overlay sat behind unrelated windows when they were focused.

Sampling the same pixels across 16 consecutive frames with the overlay open:

```
urlbar=(211,180,131)   body=(183,193,199)
... all 16 frames identical
```

Before the `ResizeBuffers` guard, the same measurement alternated between the overlay content and near-black every few frames.

**macOS** (26.6.2, Apple Silicon, 120Hz ProMotion). `isTransparent()` returns true, the overlay draws over the app, and the app is visible through everything Steam has not drawn — two captures six seconds apart show the animation in different positions, so it is the live window showing through rather than a frozen mirror. A frame counter over 6.23s gives ~117fps with the overlay open, against the 120Hz panel.

Steam's "Access Steam features from the overlay while playing" toast also drew into the window, which the mirroring path cannot do, so that independently confirms transparent mode was live.

One macOS note for anyone reproducing this: on a direct launch `gameoverlayrenderer.dylib` is never injected, so no overlay can draw — and Steam still tracks the process, so the console looks healthy either way. It has to be launched from Steam. Unrelated to this change, but it produced two false negatives before we spotted it.

**Linux** (Ubuntu 24.04, AMD RX 9070 XT, Mesa 25.2.8, XWayland, launched from Steam as a non-Steam game). Everything this PR is responsible for works, and **Steam's overlay never renders**, so the end-to-end result is unverified there. Being explicit about the split, because it matters for review:

Working:

- `isTransparent()` returns true
- `Chose visual depth 32 (ARGB: yes)` — the depth-32 visual selection this PR adds picks correctly
- Real X11 window id under XWayland (`0x6600004`)
- The hook is genuinely loaded, confirmed by grepping `/proc/self/maps` directly (the built-in check is unreliable — #80)
- `STEAM_GAME` atom set on both the Electron and overlay windows
- Shift+Tab reaching the overlay window

Not working: Steam draws nothing into the window. No overlay, no notifications, no FPS counter.

I could not find a condition under which it does render, and I do not think this is caused by this PR — but I have not proved that, so I would rather say so plainly than imply Linux is verified. **If you have any idea why Steam's Linux overlay would decline to render for an Electron app that satisfies every documented precondition, I would genuinely welcome the steer.** The most useful next measurement is whether the stock mirroring path renders on the same machine; if it does not, this PR is provably not a regression and the problem is Steam's Linux overlay with Electron generally. I'll run that on a different Linux box shortly and report back.

Compile-verified across the matrix throughout: `node-gyp rebuild` and `tsc --noEmit` pass on `macos-latest` (x64), `macos-14` (arm64), `ubuntu-latest` and `windows-latest`.

## Steamworks SDK Compatibility

- Steamworks SDK Version: n/a
- [x] Backward compatible with previous SDK versions

The overlay native module doesn't link the Steamworks SDK, so this introduces no SDK version dependency.

## Breaking Changes

- [ ] This PR includes breaking changes

Opt-in. Omit `transparent` and behaviour is unchanged on every platform.

## Documentation

- [x] Updated API documentation in `/docs`
- [x] Added inline code comments
- [x] Updated TypeScript type definitions

## Additional Notes

**Linux transparency depends on a compositing manager.** `isTransparent()` checks for one via `_NET_WM_CM_S<screen>` and reports false when there isn't one, so a bare session without a compositor keeps today's behaviour rather than getting a broken window. One caveat I should flag: wlroots-based compositors (sway, Hyprland) generally do not claim that selection under XWayland even though they composite everything, so the check is conservative there — it will report false and fall back to mirroring on a session that could actually have done transparency.

**Three pre-existing Linux bugs turned up while testing this**, all unrelated to this change and reported separately rather than bundled in here: #79 (native Wayland kills the process), #80 (the overlay-hook check greps for the Windows filename), #81 (`override_redirect` z-order — the Linux counterpart of what `ownerHwnd` fixes on Windows).

Everything here is gated on `transparent`: leave it unset and the behaviour is unchanged, on all three platforms.

Worth saying separately: the overlay window is `WS_EX_TOPMOST` on Windows today, so on the mirroring path it floats above unrelated applications regardless of focus. This PR does not change that — the owned-window treatment applies only in transparent mode, where the window is permanently on screen and the problem is unmissable. I've left the mirroring path alone rather than widen the diff, but I'm happy to fix it there too if you'd like, either here or separately. It is the Windows counterpart of #81.
