### PR TITLE
fix(loader): resolve interface accessors across SDK versions

### DIFF
--- a/src/internal/SteamAPICore.ts
+++ b/src/internal/SteamAPICore.ts
@@ -211,7 +211,7 @@ export class SteamAPICore {
       this.userInterface = this.libraryLoader.SteamAPI_SteamUser_v023();
       
       // Get Utils interface
-      this.utilsInterface = this.libraryLoader.SteamAPI_SteamUtils_v010();
+      this.utilsInterface = this.libraryLoader.SteamAPI_SteamUtils();
       if (!this.utilsInterface || this.utilsInterface === null) {
         SteamLogger.warn('[Steamworks] WARNING: Failed to get SteamUtils interface');
       }

--- a/src/internal/SteamInputManager.ts
+++ b/src/internal/SteamInputManager.ts
@@ -99,7 +99,7 @@ export class SteamInputManager {
    */
   private getSteamInputInterface(): any {
     if (!this.steamInputInterface) {
-      this.steamInputInterface = this.libraryLoader.SteamAPI_SteamInput_v006();
+      this.steamInputInterface = this.libraryLoader.SteamAPI_SteamInput();
     }
     return this.steamInputInterface;
   }

--- a/src/internal/SteamLibraryLoader.ts
+++ b/src/internal/SteamLibraryLoader.ts
@@ -91,7 +91,7 @@ export class SteamLibraryLoader {
   
   public SteamAPI_SteamUserStats_v013!: KoffiFunction;
   public SteamAPI_SteamUser_v023!: KoffiFunction;
-  public SteamAPI_SteamUtils_v010!: KoffiFunction;
+  public SteamAPI_SteamUtils!: KoffiFunction;
   public SteamAPI_ISteamUserStats_GetNumAchievements!: KoffiFunction;
   public SteamAPI_ISteamUserStats_GetAchievementName!: KoffiFunction;
   public SteamAPI_ISteamUserStats_GetAchievementDisplayAttribute!: KoffiFunction;
@@ -263,7 +263,7 @@ export class SteamLibraryLoader {
   // ========================================
   
   // Interface accessor
-  public SteamAPI_SteamNetworkingSockets_SteamAPI_v012!: KoffiFunction;
+  public SteamAPI_SteamNetworkingSockets_SteamAPI!: KoffiFunction;
   
   // P2P Listen/Connect
   public SteamAPI_ISteamNetworkingSockets_CreateListenSocketP2P!: KoffiFunction;
@@ -463,7 +463,7 @@ export class SteamLibraryLoader {
   // ========================================
   
   // Interface accessor
-  public SteamAPI_SteamInput_v006!: KoffiFunction;
+  public SteamAPI_SteamInput!: KoffiFunction;
   
   // Initialization
   public SteamAPI_ISteamInput_Init!: KoffiFunction;
@@ -835,6 +835,37 @@ export class SteamLibraryLoader {
 
     // Lazy FFI binding: defers koffi.func() symbol lookup to first call.
     // With ~200 functions, eager binding at load() adds hundreds of ms to startup.
+    // Steam's interface accessors carry a version suffix that changes between
+    // SDK releases -- SteamAPI_SteamUtils_v010 in older redistributables,
+    // _v011 in 1.65. Binding one hard-coded name makes the library work with
+    // exactly one SDK version and fail at load on every other, which is not
+    // something a consumer can work around: the redistributables are shipped
+    // by the game, not by this package.
+    //
+    // So versioned accessors are bound from a newest-first list and the first
+    // one present wins. The methods behind them are the unversioned flat
+    // functions (SteamAPI_ISteamUtils_*), which is what makes this safe: only
+    // the accessor is being version-negotiated, not the calls made through it.
+    const lfAny = (names: string[], ret: any, args: any[]): KoffiFunction => {
+      let fn: KoffiFunction | undefined;
+      const wrapper = (...a: any[]) => {
+        if (!fn) {
+          let lastError: unknown;
+          for (const name of names) {
+            try {
+              fn = this.steamLib!.func(name, ret, args);
+              break;
+            } catch (e) {
+              lastError = e;
+            }
+          }
+          if (!fn) throw lastError;
+        }
+        return fn(...a);
+      };
+      return wrapper as KoffiFunction;
+    };
+
     const lf = (name: string, ret: any, args: any[]): KoffiFunction => {
       let fn: KoffiFunction | undefined;
       const wrapper = (...a: any[]) => {
@@ -859,7 +890,11 @@ export class SteamLibraryLoader {
     
     this.SteamAPI_SteamUserStats_v013 = lf('SteamAPI_SteamUserStats_v013', 'void*', []);
     this.SteamAPI_SteamUser_v023 = lf('SteamAPI_SteamUser_v023', 'void*', []);
-    this.SteamAPI_SteamUtils_v010 = lf('SteamAPI_SteamUtils_v010', 'void*', []);
+    this.SteamAPI_SteamUtils = lfAny(
+      ['SteamAPI_SteamUtils_v011', 'SteamAPI_SteamUtils_v010'],
+      'void*',
+      [],
+    );
     
     this.SteamAPI_ISteamUserStats_GetNumAchievements = lf('SteamAPI_ISteamUserStats_GetNumAchievements', 'uint32', ['void*']);
     this.SteamAPI_ISteamUserStats_GetAchievementName = lf('SteamAPI_ISteamUserStats_GetAchievementName', 'str', ['void*', 'uint32']);
@@ -1038,7 +1073,11 @@ export class SteamLibraryLoader {
     // ========================================
     
     // Interface accessor
-    this.SteamAPI_SteamNetworkingSockets_SteamAPI_v012 = lf('SteamAPI_SteamNetworkingSockets_SteamAPI_v012', 'void*', []);
+    this.SteamAPI_SteamNetworkingSockets_SteamAPI = lfAny(
+      ['SteamAPI_SteamNetworkingSockets_SteamAPI_v013', 'SteamAPI_SteamNetworkingSockets_SteamAPI_v012'],
+      'void*',
+      [],
+    );
     
     // P2P Listen/Connect
     // CreateListenSocketP2P(nLocalVirtualPort, nOptions, pOptions) -> HSteamListenSocket
@@ -1243,7 +1282,11 @@ export class SteamLibraryLoader {
     // ========================================
     
     // Interface accessor
-    this.SteamAPI_SteamInput_v006 = lf('SteamAPI_SteamInput_v006', 'void*', []);
+    this.SteamAPI_SteamInput = lfAny(
+      ['SteamAPI_SteamInput_v007', 'SteamAPI_SteamInput_v006'],
+      'void*',
+      [],
+    );
     
     // Initialization
     this.SteamAPI_ISteamInput_Init = lf('SteamAPI_ISteamInput_Init', 'bool', ['void*', 'bool']);

--- a/src/internal/SteamNetworkingSocketsManager.ts
+++ b/src/internal/SteamNetworkingSocketsManager.ts
@@ -267,7 +267,7 @@ export class SteamNetworkingSocketsManager {
    */
   private getInterface(): any {
     if (!this.networkingSocketsInterface) {
-      this.networkingSocketsInterface = this.libraryLoader.SteamAPI_SteamNetworkingSockets_SteamAPI_v012();
+      this.networkingSocketsInterface = this.libraryLoader.SteamAPI_SteamNetworkingSockets_SteamAPI();
     }
     return this.networkingSocketsInterface;
   }

--- a/src/internal/SteamUtilsManager.ts
+++ b/src/internal/SteamUtilsManager.ts
@@ -30,7 +30,7 @@ import {
  * 
  * @remarks
  * All methods require the Steam API to be initialized. The manager uses
- * the SteamAPI_SteamUtils_v010 interface accessor for API calls.
+ * the SteamAPI_SteamUtils interface accessor for API calls.
  * 
  * @example Get system information
  * ```typescript
@@ -100,7 +100,7 @@ export class SteamUtilsManager {
     if (!status.initialized) {
       return null;
     }
-    return this.libraryLoader.SteamAPI_SteamUtils_v010();
+    return this.libraryLoader.SteamAPI_SteamUtils();
   }
 
   // ========================================


### PR DESCRIPTION
## Description

`SteamLibraryLoader` binds Steam's interface accessors by their exact versioned export name. Those names change between SDK releases, so a game shipping any redistributable other than the one these were written against fails at load.

On SDK 1.65:

```
Cannot find function 'SteamAPI_SteamUtils_v010' in shared library
```

This binds the three affected accessors from a newest-first list and takes the first that resolves.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

None open that I could find.

## Motivation and Context

The version suffix is on the *accessor* export, not on the methods reached through it — those are the unversioned flat API (`SteamAPI_ISteamUtils_GetAppID` and friends). So the accessor version decides whether the library loads, and nothing else.

That makes the current binding stricter than it needs to be, and the strictness lands on someone who cannot do anything about it: the Steamworks redistributables are shipped by the game, chosen from whatever Valve currently offers on the partner site. A consumer who downloads today's SDK gets 1.65 and this package will not initialise, with no supported way to pin an older one.

Three accessors differ on 1.65:

| Accessor | Bound | SDK 1.65 |
| --- | --- | --- |
| `SteamAPI_SteamUtils` | `_v010` | `_v011` |
| `SteamAPI_SteamInput` | `_v006` | `_v007` |
| `SteamAPI_SteamNetworkingSockets_SteamAPI` | `_v012` | `_v013` |

Only `SteamUtils` is reached during `init()`, so it is the one that breaks startup outright; the other two fail later, when something touches Input or Networking Sockets. `lf()` is lazy, which is why they get that far.

## Changes Made

- Added `lfAny(names, ret, args)` alongside the existing `lf()`. Same lazy binding, but it walks a list of candidate export names and keeps the first that resolves, rethrowing the last error if none do.
- Bound the three accessors above through it, newest first.
- Dropped the version suffix from those three property names (`SteamAPI_SteamUtils_v010` → `SteamAPI_SteamUtils`, and likewise for the other two). A field named for v010 that may hold v011 seemed worse than a field with no version in the name at all. They are on `SteamLibraryLoader`, which is under `internal/` and not part of the package's public surface, but happy to keep the old names if you would rather not touch them.

No call sites change behaviour: they were already calling the accessor and using whatever pointer came back.

## Steam API Impact

- [x] No Steam API changes

## Testing

### Test Environment
- OS: Windows 11
- Node.js version: v22.23.2
- Electron version: v33.4.11
- Steam Client: Running
- Steamworks SDK: 1.65

### Test Cases

- [x] Manual testing completed
- [x] Tested with Steam client running
- [ ] Unit tests pass — I did not run the repo's test scripts; they need a Steam client per-suite and exercise API surfaces this does not touch
- [ ] Integration tests pass
- [ ] Tested without Steam client

### Test Results

Against SDK 1.65, which fails to initialise at all on `main`:

- `init()` succeeds
- `friends.getPersonaName()`, `getStatus().steamId`
- `user.getAuthTicketForWebApi()` → 240-byte ticket, then `cancelAuthTicket()`
- `richPresence.setRichPresence()`
- `matchmaking.createLobby()` / `setLobbyData()` / `getLobbyData()` / `leaveLobby()`

I have not tested Input or Networking Sockets — I do not use either, so those two entries are from reading the 1.65 exports rather than from running them. Worth someone confirming if you have a controller to hand.

I also have not tested against an older SDK, since I no longer have one; the fallback path is the existing name, unchanged, so it should be exactly today's behaviour.

## Steamworks SDK Compatibility

- Steamworks SDK Version: 1.65, with the older versions kept as fallbacks
- [x] Backward compatible with previous SDK versions

## Breaking Changes

- [ ] This PR includes breaking changes

## Documentation

- [x] Added inline code comments

## Additional Notes

There are other versioned accessors in the loader (`SteamAPI_SteamUser_v023`, `SteamAPI_SteamFriends_v018` and so on) that happen to match on 1.65, so I have left them alone rather than convert everything speculatively. If you would prefer the whole set moved onto `lfAny` for consistency, say so and I will extend it.
